### PR TITLE
Added sys/sysmacros.h includes

### DIFF
--- a/src/asustrx.c
+++ b/src/asustrx.c
@@ -69,7 +69,7 @@
 #include <unistd.h>
 #include <endian.h>
 #include <byteswap.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 // always flip, regardless of endianness of machine
 u_int32_t flip_endian(u_int32_t nValue)

--- a/src/configure
+++ b/src/configure
@@ -561,7 +561,7 @@ PACKAGE_URL=''
 ac_includes_default="\
 #include <stdio.h>
 #ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h>
+# include <sys/types.h sys/sysmacros.h>
 #endif
 #ifdef HAVE_SYS_STAT_H
 # include <sys/stat.h>
@@ -2863,7 +2863,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdarg.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/types.h sys/sysmacros.h>
 #include <sys/stat.h>
 /* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
 struct buf { int x; };
@@ -3595,7 +3595,7 @@ $as_echo "#define STDC_HEADERS 1" >>confdefs.h
 fi
 
 # On IRIX 5.3, sys/types and inttypes.h are conflicting.
-for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
+for ac_header in sys/types.h sys/sysmacros.h sys/stat.h stdlib.h string.h memory.h strings.h \
 		  inttypes.h stdint.h unistd.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`

--- a/src/cramfs-2.x/cramfsck.c
+++ b/src/cramfs-2.x/cramfsck.c
@@ -36,7 +36,7 @@
 #define INCLUDE_FS_TESTS	/* include cramfs checking and extraction */
 
 #define _GNU_SOURCE
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <sys/stat.h>

--- a/src/cramfs-2.x/mkcramfs.c
+++ b/src/cramfs-2.x/mkcramfs.c
@@ -22,7 +22,7 @@
  * If you change the disk format of cramfs, please update fs/cramfs/README.
  */
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/crcalc/common.c
+++ b/src/crcalc/common.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/crcalc/crcalc.c
+++ b/src/crcalc/crcalc.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/firmware-tools/airlink.c
+++ b/src/firmware-tools/airlink.c
@@ -20,7 +20,7 @@ AIRLINK AR525W firmware image structure
 #include <string.h>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <netinet/in.h>

--- a/src/firmware-tools/fw.h
+++ b/src/firmware-tools/fw.h
@@ -19,7 +19,7 @@
 #ifndef FW_INCLUDED
 #define FW_INCLUDED
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #define MAGIC_HEADER	"OPEN"
 #define MAGIC_PART	"PART"

--- a/src/firmware-tools/mkfwimage.c
+++ b/src/firmware-tools/mkfwimage.c
@@ -17,7 +17,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/firmware-tools/mkfwimage2.c
+++ b/src/firmware-tools/mkfwimage2.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/firmware-tools/nand_ecc.c
+++ b/src/firmware-tools/nand_ecc.c
@@ -21,7 +21,7 @@
  */
 
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/firmware-tools/ptgen.c
+++ b/src/firmware-tools/ptgen.c
@@ -20,7 +20,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/firmware-tools/seama.c
+++ b/src/firmware-tools/seama.c
@@ -42,7 +42,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <string.h>

--- a/src/firmware-tools/wrt400n.c
+++ b/src/firmware-tools/wrt400n.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 
 #include "cyg_crc.h"

--- a/src/jffs2/sunjffs2.c
+++ b/src/jffs2/sunjffs2.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/src/lzma/C/Common/C_FileIO.h
+++ b/src/lzma/C/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/mountcp/mountsu.c
+++ b/src/mountcp/mountsu.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/src/mountcp/umountsu.c
+++ b/src/mountcp/umountsu.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/getdelim.h
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/getdelim.h
@@ -21,7 +21,7 @@
 /* Get size_t, FILE, ssize_t.  And getdelim, if available.  */
 # include <stddef.h>
 # include <stdio.h>
-# include <sys/types.h>
+# include <sys/sysmacros.h>
 
 #if !HAVE_DECL_GETDELIM
 ssize_t getdelim (char **lineptr, size_t *n, int delimiter, FILE *stream);

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/getline.h
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/getline.h
@@ -21,7 +21,7 @@
 /* Get size_t, FILE, ssize_t.  And getline, if available.  */
 # include <stddef.h>
 # include <stdio.h>
-# include <sys/types.h>
+# include <sys/sysmacros.h>
 
 #if !HAVE_DECL_GETLINE
 ssize_t getline (char **lineptr, size_t *n, FILE *stream);

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/lzma/decompress/vxTypesOld.h
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/lzma/decompress/vxTypesOld.h
@@ -72,7 +72,7 @@ This header file contains a mixture of stuff.
 extern "C" {
 #endif
 
-#include "sys/types.h"
+#include "sys/sysmacros.h"
 
 /* vxWorks types */
 

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
@@ -26,7 +26,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/read_fs.c
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/read_fs.c
@@ -26,7 +26,7 @@ extern int add_file(int, int, unsigned int *, int, unsigned int, int, int);
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/sort.c
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/sort.c
@@ -25,7 +25,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-2.0-nb4/nb4-unsquashfs/brcm-lzma/vxTypesOld.h
+++ b/src/others/squashfs-2.0-nb4/nb4-unsquashfs/brcm-lzma/vxTypesOld.h
@@ -72,7 +72,7 @@ This header file contains a mixture of stuff.
 extern "C" {
 #endif
 
-#include "sys/types.h"
+#include "sys/sysmacros.h"
 
 /* vxWorks types */
 

--- a/src/others/squashfs-2.0-nb4/nb4-unsquashfs/nb4-unsquash.c
+++ b/src/others/squashfs-2.0-nb4/nb4-unsquashfs/nb4-unsquash.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>

--- a/src/others/squashfs-2.2-r2-7z/mksquashfs.c
+++ b/src/others/squashfs-2.2-r2-7z/mksquashfs.c
@@ -30,7 +30,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-2.2-r2-7z/p7zip/Windows/FileFind.h
+++ b/src/others/squashfs-2.2-r2-7z/p7zip/Windows/FileFind.h
@@ -7,7 +7,7 @@
 #include "FileName.h"
 #include "Defs.h"
 
-#include <sys/types.h> /* for DIR */
+#include <sys/sysmacros.h> /* for DIR */
 #include <dirent.h>
 
 namespace NWindows {

--- a/src/others/squashfs-2.2-r2-7z/read_fs.c
+++ b/src/others/squashfs-2.2-r2-7z/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(int, int, unsigned int *, int, unsigned int, int, int);
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-2.2-r2-7z/sort.c
+++ b/src/others/squashfs-2.2-r2-7z/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-2.2-r2-7z/unsquashfs.c
+++ b/src/others/squashfs-2.2-r2-7z/unsquashfs.c
@@ -27,7 +27,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.0-e2100/lzma/C/Common/C_FileIO.h
+++ b/src/others/squashfs-3.0-e2100/lzma/C/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-3.0-e2100/mksquashfs.c
+++ b/src/others/squashfs-3.0-e2100/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.0-e2100/read_fs.c
+++ b/src/others/squashfs-3.0-e2100/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, unsigned int *, int, unsigned int, int
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.0-e2100/sort.c
+++ b/src/others/squashfs-3.0-e2100/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.0-e2100/unsquashfs.c
+++ b/src/others/squashfs-3.0-e2100/unsquashfs.c
@@ -24,7 +24,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-hg612-lzma/lzma443/C/Common/C_FileIO.h
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/lzma443/C/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/sort.c
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/unsquashfs.c
@@ -26,7 +26,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-lzma/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-3.2-r2-lzma/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/sort.c
+++ b/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/unsquashfs.c
@@ -26,7 +26,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-rtn12/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-rtn12/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.2-r2-rtn12/read_fs.c
+++ b/src/others/squashfs-3.2-r2-rtn12/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-rtn12/sort.c
+++ b/src/others/squashfs-3.2-r2-rtn12/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-rtn12/unsquashfs.c
+++ b/src/others/squashfs-3.2-r2-rtn12/unsquashfs.c
@@ -26,7 +26,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-wnr1000/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-wnr1000/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.2-r2-wnr1000/read_fs.c
+++ b/src/others/squashfs-3.2-r2-wnr1000/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-wnr1000/sort.c
+++ b/src/others/squashfs-3.2-r2-wnr1000/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2-wnr1000/unsquashfs.c
+++ b/src/others/squashfs-3.2-r2-wnr1000/unsquashfs.c
@@ -26,7 +26,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.2-r2/read_fs.c
+++ b/src/others/squashfs-3.2-r2/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2/sort.c
+++ b/src/others/squashfs-3.2-r2/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.2-r2/unsquashfs.c
+++ b/src/others/squashfs-3.2-r2/unsquashfs.c
@@ -26,7 +26,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3-grml-lzma/lzma/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-3.3-grml-lzma/lzma/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/sort.c
+++ b/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/unsquashfs.c
@@ -27,7 +27,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3-lzma/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-3.3-lzma/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
@@ -29,7 +29,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/sort.c
+++ b/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/unsquashfs.c
@@ -27,7 +27,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/src/others/squashfs-3.3/mksquashfs.c
+++ b/src/others/squashfs-3.3/mksquashfs.c
@@ -30,7 +30,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -41,7 +41,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.3/read_fs.c
+++ b/src/others/squashfs-3.3/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3/sort.c
+++ b/src/others/squashfs-3.3/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.3/unsquashfs.c
+++ b/src/others/squashfs-3.3/unsquashfs.c
@@ -28,7 +28,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.4-cisco/lzma/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-3.4-cisco/lzma/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/mksquashfs.c
@@ -31,7 +31,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -42,7 +42,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/read_fs.c
@@ -28,7 +28,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/sort.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/sort.c
@@ -27,7 +27,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/unsquashfs.c
@@ -28,7 +28,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/src/others/squashfs-3.4-nb4/lzma465/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-3.4-nb4/lzma465/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -41,7 +41,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/sort.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
@@ -27,7 +27,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/src/others/squashfs-4.0-lzma/lzma/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-4.0-lzma/lzma/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-4.0-lzma/mksquashfs.c
+++ b/src/others/squashfs-4.0-lzma/mksquashfs.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -41,7 +41,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-4.0-lzma/mksquashfs.c.orig
+++ b/src/others/squashfs-4.0-lzma/mksquashfs.c.orig
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -41,7 +41,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-4.0-lzma/pseudo.c
+++ b/src/others/squashfs-4.0-lzma/pseudo.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "pseudo.h"
 

--- a/src/others/squashfs-4.0-lzma/read_fs.c
+++ b/src/others/squashfs-4.0-lzma/read_fs.c
@@ -31,7 +31,7 @@ extern unsigned int get_guid(unsigned int);
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.0-lzma/sort.c
+++ b/src/others/squashfs-4.0-lzma/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.0-lzma/unsquashfs.h
+++ b/src/others/squashfs-4.0-lzma/unsquashfs.h
@@ -24,7 +24,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/src/others/squashfs-4.0-realtek/lzma/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-4.0-realtek/lzma/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-4.0-realtek/mksquashfs.c
+++ b/src/others/squashfs-4.0-realtek/mksquashfs.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-4.0-realtek/pseudo.c
+++ b/src/others/squashfs-4.0-realtek/pseudo.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/wait.h>
 
 #include "pseudo.h"

--- a/src/others/squashfs-4.0-realtek/read_fs.c
+++ b/src/others/squashfs-4.0-realtek/read_fs.c
@@ -31,7 +31,7 @@ extern unsigned int get_guid(unsigned int);
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.0-realtek/sort.c
+++ b/src/others/squashfs-4.0-realtek/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.0-realtek/unsquashfs.h
+++ b/src/others/squashfs-4.0-realtek/unsquashfs.h
@@ -24,7 +24,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/src/others/squashfs-4.2-official/mksquashfs.c
+++ b/src/others/squashfs-4.2-official/mksquashfs.c
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -42,7 +42,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-4.2-official/pseudo.c
+++ b/src/others/squashfs-4.2-official/pseudo.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/wait.h>
 
 #include "pseudo.h"

--- a/src/others/squashfs-4.2-official/read_fs.c
+++ b/src/others/squashfs-4.2-official/read_fs.c
@@ -25,7 +25,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.2-official/sort.c
+++ b/src/others/squashfs-4.2-official/sort.c
@@ -27,7 +27,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.2-official/unsquashfs.c
+++ b/src/others/squashfs-4.2-official/unsquashfs.c
@@ -30,7 +30,7 @@
 #include "xattr.h"
 
 #include <sys/sysinfo.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 struct cache *fragment_cache, *data_cache;
 struct queue *to_reader, *to_deflate, *to_writer, *from_writer;

--- a/src/others/squashfs-4.2-official/unsquashfs.h
+++ b/src/others/squashfs-4.2-official/unsquashfs.h
@@ -25,7 +25,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/src/others/squashfs-4.2-official/xattr.c
+++ b/src/others/squashfs-4.2-official/xattr.c
@@ -27,7 +27,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.2/lzma-4.65/CPP/7zip/Compress/LZMA_Alone/lzmp.cpp
+++ b/src/others/squashfs-4.2/lzma-4.65/CPP/7zip/Compress/LZMA_Alone/lzmp.cpp
@@ -40,7 +40,7 @@ typedef vector<string> stringVector;
 #include <getopt.h>
 #include <signal.h>
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <utime.h>
 #include <sys/time.h> // futimes()

--- a/src/others/squashfs-4.2/lzma-4.65/CPP/Common/C_FileIO.h
+++ b/src/others/squashfs-4.2/lzma-4.65/CPP/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/others/squashfs-4.2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-4.2/squashfs-tools/mksquashfs.c
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -42,7 +42,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <pthread.h>
 #include <math.h>

--- a/src/others/squashfs-4.2/squashfs-tools/pseudo.c
+++ b/src/others/squashfs-4.2/squashfs-tools/pseudo.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
 

--- a/src/others/squashfs-4.2/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-4.2/squashfs-tools/read_fs.c
@@ -25,7 +25,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.2/squashfs-tools/sort.c
+++ b/src/others/squashfs-4.2/squashfs-tools/sort.c
@@ -27,7 +27,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/others/squashfs-4.2/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-4.2/squashfs-tools/unsquashfs.c
@@ -29,7 +29,7 @@
 #include "compressor.h"
 #include "xattr.h"
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 struct cache *fragment_cache, *data_cache;
 struct queue *to_reader, *to_deflate, *to_writer, *from_writer;

--- a/src/others/squashfs-4.2/squashfs-tools/unsquashfs.h
+++ b/src/others/squashfs-4.2/squashfs-tools/unsquashfs.h
@@ -25,7 +25,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/src/others/squashfs-4.2/squashfs-tools/xattr.c
+++ b/src/others/squashfs-4.2/squashfs-tools/xattr.c
@@ -27,7 +27,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/splitter3.cc
+++ b/src/splitter3.cc
@@ -30,11 +30,11 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include <endian.h>
 #include <byteswap.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "untrx.h"
 

--- a/src/squashfs-2.1-r2/mksquashfs.c
+++ b/src/squashfs-2.1-r2/mksquashfs.c
@@ -26,7 +26,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-2.1-r2/read_fs.c
+++ b/src/squashfs-2.1-r2/read_fs.c
@@ -26,7 +26,7 @@ extern int add_file(int, int, unsigned int *, int, unsigned int, int, int);
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-2.1-r2/sort.c
+++ b/src/squashfs-2.1-r2/sort.c
@@ -25,7 +25,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-2.1-r2/unsquashfs.c
+++ b/src/squashfs-2.1-r2/unsquashfs.c
@@ -27,7 +27,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0-lzma-damn-small-variant/lzma/C/Common/C_FileIO.h
+++ b/src/squashfs-3.0-lzma-damn-small-variant/lzma/C/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
@@ -35,7 +35,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0-lzma-damn-small-variant/read_fs.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, unsigned int *, int, unsigned int, int
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0-lzma-damn-small-variant/sort.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0-lzma-damn-small-variant/unsquashfs.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/unsquashfs.c
@@ -24,7 +24,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0/mksquashfs.c
+++ b/src/squashfs-3.0/mksquashfs.c
@@ -35,7 +35,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0/read_fs.c
+++ b/src/squashfs-3.0/read_fs.c
@@ -27,7 +27,7 @@ extern int add_file(long long, long long, unsigned int *, int, unsigned int, int
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0/sort.c
+++ b/src/squashfs-3.0/sort.c
@@ -26,7 +26,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/squashfs-3.0/unsquashfs.c
+++ b/src/squashfs-3.0/unsquashfs.c
@@ -27,7 +27,7 @@
 #define TRUE 1
 #define FALSE 0
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/uncramfs-lzma/lzma-rg/SRC/Common/C_FileIO.h
+++ b/src/uncramfs-lzma/lzma-rg/SRC/Common/C_FileIO.h
@@ -4,7 +4,7 @@
 #define __COMMON_C_FILEIO_H
 
 #include <stdio.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "Types.h"
 #include "MyWindows.h"

--- a/src/uncramfs-lzma/lzma-uncramfs.c
+++ b/src/uncramfs-lzma/lzma-uncramfs.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <errno.h>
 //#include <dirent.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <sys/fcntl.h>

--- a/src/uncramfs/uncramfs.c
+++ b/src/uncramfs/uncramfs.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <errno.h>
 //#include <dirent.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <sys/fcntl.h>

--- a/src/untrx.cc
+++ b/src/untrx.cc
@@ -29,11 +29,11 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include <endian.h>
 #include <byteswap.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #include "untrx.h"
 

--- a/src/webcomp-tools/common.c
+++ b/src/webcomp-tools/common.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <arpa/inet.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/yaffs2utils/mkyaffs2.c
+++ b/src/yaffs2utils/mkyaffs2.c
@@ -29,7 +29,7 @@
 #include <libgen.h>
 #include <limits.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/param.h>
 #ifdef _HAVE_OSX_SYSLIMITS
 #include <sys/syslimits.h>


### PR DESCRIPTION
makedev(), major() and minor() macros have been moved from sys/types.h
to sys/sysmacros.h

Signed-off-by: Mark Ulrich <mark.ulrich.86@gmail.com>