### PR TITLE
Fix 'File does not exist!'

### DIFF
--- a/extract-firmware.sh
+++ b/extract-firmware.sh
@@ -16,8 +16,8 @@ else
 	SUDO=""
 fi
 
-IMG=$(readlink -f $IMG)
-DIR=$(readlink -f $DIR)
+IMG=$(readlink -f "$IMG")
+DIR=$(readlink -f "$DIR")
 
 # Make sure we're operating out of the FMK directory
 cd $(dirname $(readlink -f $0))


### PR DESCRIPTION
IFS typically includes the space, tab, and the newline, while path includes IFS `readlink` will split path it to multiples.
Add quote to escape it.