### PR TITLE
#include <unistd.h> to avoid warnings

### DIFF
--- a/src/bff/bff_huffman_decompress.c
+++ b/src/bff/bff_huffman_decompress.c
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #define	PACK_HEADER_LENGTH	1
 #define	HTREE_MAXLEVEL		24
 


### PR DESCRIPTION
My compiler warns about implicit declarations of `read()` and `dup()`