### PR TITLE
Fix build error on gcc-10

### DIFF
--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/read_fs.c
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/read_fs.c
@@ -53,7 +53,7 @@ extern int add_file(int, int, unsigned int *, int, unsigned int, int, int);
 
 #define ERROR(s, args...)		fprintf(stderr, s, ## args)
 
-int swap;
+extern int swap;
 
 int read_block(int fd, int start, int *next, unsigned char *block, squashfs_super_block *sBlk)
 {

--- a/src/others/squashfs-3.0-e2100/mksquashfs.c
+++ b/src/others/squashfs-3.0-e2100/mksquashfs.c
@@ -1347,7 +1347,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.0-e2100/read_fs.c
+++ b/src/others/squashfs-3.0-e2100/read_fs.c
@@ -61,7 +61,7 @@ extern int add_file(long long, long long, unsigned int *, int, unsigned int, int
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)
 {

--- a/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
@@ -2205,7 +2205,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
@@ -63,7 +63,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern struct sqlzma_un un;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
@@ -2209,7 +2209,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/read_fs.c
@@ -63,7 +63,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern struct sqlzma_un un;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.2-r2-rtn12/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-rtn12/mksquashfs.c
@@ -2234,7 +2234,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.2-r2-rtn12/read_fs.c
+++ b/src/others/squashfs-3.2-r2-rtn12/read_fs.c
@@ -63,7 +63,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern int lzma;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.2-r2-wnr1000/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-wnr1000/mksquashfs.c
@@ -2233,7 +2233,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.2-r2-wnr1000/read_fs.c
+++ b/src/others/squashfs-3.2-r2-wnr1000/read_fs.c
@@ -62,7 +62,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern int lzma;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.2-r2/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2/mksquashfs.c
@@ -2211,7 +2211,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.2-r2/read_fs.c
+++ b/src/others/squashfs-3.2-r2/read_fs.c
@@ -61,7 +61,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)
 {

--- a/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
@@ -2348,7 +2348,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/read_fs.c
@@ -63,7 +63,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern struct sqlzma_un un;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
@@ -2355,7 +2355,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/read_fs.c
@@ -63,7 +63,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern struct sqlzma_un un;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.3/mksquashfs.c
+++ b/src/others/squashfs-3.3/mksquashfs.c
@@ -2353,7 +2353,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.3/read_fs.c
+++ b/src/others/squashfs-3.3/read_fs.c
@@ -61,7 +61,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)
 {

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/mksquashfs.c
@@ -2718,7 +2718,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/read_fs.c
@@ -66,7 +66,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern int gLzmaEnable;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
@@ -2704,7 +2704,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/read_fs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/read_fs.c
@@ -63,7 +63,7 @@ extern int add_file(long long, long long, long long, unsigned int *, int, unsign
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 extern struct sqlzma_un un;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
@@ -48,7 +48,7 @@
 #include <sys/ioctl.h>
 #include <sys/time.h>
 
-#include <sys/sysctl.h>
+
 
 #ifndef linux
 #define __BYTE_ORDER BYTE_ORDER

--- a/src/others/squashfs-4.0-lzma/mksquashfs.c
+++ b/src/others/squashfs-4.0-lzma/mksquashfs.c
@@ -3129,7 +3129,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
 	struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0) {

--- a/src/others/squashfs-4.0-realtek/mksquashfs.c
+++ b/src/others/squashfs-4.0-realtek/mksquashfs.c
@@ -3177,7 +3177,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
 	struct inode_info *inode_info, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0) {

--- a/src/others/squashfs-4.2-official/mksquashfs.c
+++ b/src/others/squashfs-4.2-official/mksquashfs.c
@@ -3340,7 +3340,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
 	struct inode_info *inode_info, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0) {

--- a/src/others/squashfs-4.2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-4.2/squashfs-tools/mksquashfs.c
@@ -3355,7 +3355,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir,
 	struct inode_info *inode_info, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0) {

--- a/src/squashfs-2.1-r2/read_fs.c
+++ b/src/squashfs-2.1-r2/read_fs.c
@@ -48,7 +48,7 @@ extern int add_file(int, int, unsigned int *, int, unsigned int, int, int);
 
 #define ERROR(s, args...)		fprintf(stderr, s, ## args)
 
-int swap;
+extern int swap;
 
 int read_block(int fd, int start, int *next, unsigned char *block, squashfs_super_block *sBlk)
 {

--- a/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
@@ -1371,7 +1371,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/squashfs-3.0-lzma-damn-small-variant/read_fs.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/read_fs.c
@@ -61,7 +61,7 @@ extern int add_file(long long, long long, unsigned int *, int, unsigned int, int
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)
 {

--- a/src/squashfs-3.0/mksquashfs.c
+++ b/src/squashfs-3.0/mksquashfs.c
@@ -1378,7 +1378,7 @@ struct inode_info *lookup_inode(struct stat *buf)
 }
 
 
-inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
+static inline void add_dir_entry(char *name, char *pathname, struct dir_info *sub_dir, struct inode_info *inode_info, void *data, struct dir_info *dir)
 {
 	if((dir->count % DIR_ENTRIES) == 0)
 		if((dir->list = realloc(dir->list, (dir->count + DIR_ENTRIES) * sizeof(struct dir_ent *))) == NULL)

--- a/src/squashfs-3.0/read_fs.c
+++ b/src/squashfs-3.0/read_fs.c
@@ -61,7 +61,7 @@ extern int add_file(long long, long long, unsigned int *, int, unsigned int, int
 						fprintf(stderr, s, ## args); \
 					} while(0)
 
-int swap;
+extern int swap;
 
 int read_block(int fd, long long start, long long *next, unsigned char *block, squashfs_super_block *sBlk)
 {

--- a/src/webcomp-tools/common.c
+++ b/src/webcomp-tools/common.c
@@ -10,6 +10,8 @@
 #include <elf.h>
 #include "common.h"
 
+struct global globals;
+
 /* Given the physical and virtual section loading addresses, convert a virtual address to a physical file offset */
 uint32_t file_offset(uint32_t address, uint32_t virtual, uint32_t physical)
 {

--- a/src/webcomp-tools/common.h
+++ b/src/webcomp-tools/common.h
@@ -38,7 +38,7 @@ struct entry_info
 	struct new_file_entry *new_entry;
 };
 
-struct global
+extern struct global
 {
 	int endianess;
 	int use_new_format;


### PR DESCRIPTION
Fix some build errors on gcc-10.
- multiple definition of `swap' - src/squashfs
- undefined reference to add_dir_entry - src/squashfs
- multiple definition of  `globals' - src/webcomp-tools
- sys/sysctl.h no such file or directory - src/squashfs