### PR TITLE
fix (some of the) implicit function declarations

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -14,4 +14,15 @@ AC_CHECK_LIB([z],[crc32],[],[echo "error: missing zlib library" && exit],[])
 AC_CHECK_HEADERS([zlib.h],[],[echo "error: missing zlib header files" && exit])
 AC_CHECK_HEADERS([lzma.h],[],[echo "error: missing liblzma header files" && exit])
 
+# Check for -Werror support
+saved_cflags="$CFLAGS"
+saved_cxxflags="$CXXFLAGS"
+
+CFLAGS="-Werror-implicit-function-declaration"
+CXXFLAGS="-Werror-implicit-function-declaration"
+AC_MSG_CHECKING([whether CC and CXX supports -Werror-implicit-function-declaration])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); saved_cflags="${saved_cflags} -Werror-implicit-function-declaration" saved_cxxflags="${saved_cxxflags} -Werror-implicit-function-declaration"], [AC_MSG_RESULT([no])])
+CFLAGS="$saved_cflags"
+CXXFLAGS="$saved_cxxflags"
+
 AC_OUTPUT

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
@@ -20,6 +20,9 @@
  * mksquashfs.c
  */
 
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 #define TRUE 1
 #include <pwd.h>
 #include <grp.h>
@@ -33,6 +36,7 @@
 #include <dirent.h>
 #include <string.h>
 #include <zlib.h>
+#include <ctype.h>
 #ifdef __MACOSX__
   #define __BYTE_ORDER BYTE_ORDER
   #define __BIG_ENDIAN BIG_ENDIAN
@@ -44,6 +48,7 @@
 #include <signal.h>
 #include <setjmp.h>
 #include <sys/mman.h>
+#include <libgen.h>
 
 #include "mksquashfs.h"
 #include <squashfs_fs.h>

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/unsquashfs.c
@@ -48,6 +48,7 @@
 #include <math.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
+#include <sys/sysinfo.h>
 
 #ifndef linux
 #define __BYTE_ORDER BYTE_ORDER

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
@@ -47,6 +47,7 @@
 #include <math.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
+#include <sys/sysinfo.h>
 
 #ifndef linux
 #define __BYTE_ORDER BYTE_ORDER

--- a/src/others/squashfs-4.0-lzma/unsquashfs.h
+++ b/src/others/squashfs-4.0-lzma/unsquashfs.h
@@ -44,6 +44,7 @@
 #include <math.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
+#include <sys/sysinfo.h>
 
 #ifndef linux
 #define __BYTE_ORDER BYTE_ORDER

--- a/src/uncramfs/uncramfs.c
+++ b/src/uncramfs/uncramfs.c
@@ -9,7 +9,7 @@
 
 // C things
 #include <stdio.h>
-//#include <stdlib.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 


### PR DESCRIPTION
These ones still remain, I needed only the extract part so didn't dig in further:
```
mksquashfs.c:1590:2: warning: implicit declaration of function ‘dir_scan2’; did you mean ‘dir_scan’? [-Wimplicit-function-declaration]
mksquashfs.c:1559:2: warning: implicit declaration of function ‘dir_scan2’; did you mean ‘dir_scan’? [-Wimplicit-function-declaration]
mksquashfs.c:2428:2: warning: implicit declaration of function ‘dir_scan2’; did you mean ‘dir_scan’? [-Wimplicit-function-declaration]
squashfs/mksquashfs.c:1308:12: warning: implicit declaration of function ‘devtable_readdir’; did you mean ‘linux_readdir’? [-Wimplicit-function-declaration]
```
