### PR TITLE
Fix shared-ng.inc inclusion with CWD other than the fmk install dir

### DIFF
--- a/shared-ng.inc
+++ b/shared-ng.inc
@@ -1,4 +1,4 @@
-VERSION=$(cat firmware_mod_kit_version.txt)
+VERSION=$(cat "$(dirname "${BASH_SOURCE[0]}")"/firmware_mod_kit_version.txt)
 IMAGE_PARTS="$DIR/image_parts"
 LOGS="$DIR/logs"
 CONFLOG="$LOGS/config.log"
@@ -8,4 +8,4 @@ FSIMG="$IMAGE_PARTS/rootfs.img"
 HEADER_IMAGE="$IMAGE_PARTS/header.img"
 FOOTER_IMAGE="$IMAGE_PARTS/footer.img"
 FWOUT="$DIR/new-firmware.bin"
-BINWALK="./src/binwalk-2.1.1/src/scripts/binwalk -v"
+BINWALK="$(dirname "${BASH_SOURCE[0]}")/src/binwalk-2.1.1/src/scripts/binwalk -v"


### PR DESCRIPTION
Some of the fmk scripts (such as `extract-multisquashfs-firmware.sh`) don't chdir to the fmk directory, causing the `shared-ng.inc` script to fail when sourced, as it assumes that it's running in the fmk directory. This PR makes `shared-ng.inc` sourceable from anywhere.