### PR TITLE
Fix compile errors in kali linux 2025

### DIFF
--- a/src/cramfs-2.x/mkcramfs.c
+++ b/src/cramfs-2.x/mkcramfs.c
@@ -217,10 +217,9 @@ static void eliminate_doubles(struct entry *root, struct entry *orig) {
  * We define our own sorting function instead of using alphasort which
  * uses strcoll and changes ordering based on locale information.
  */
-static int cramsort (const void *a, const void *b)
+static int cramsort(const struct dirent **a, const struct dirent **b)
 {
-	return strcmp ((*(const struct dirent **) a)->d_name,
-		       (*(const struct dirent **) b)->d_name);
+	return strcmp((*a)->d_name, (*b)->d_name);
 }
 
 static unsigned int parse_directory(struct entry *root_entry, const char *name, struct entry **prev, loff_t *fslen_ub)

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
@@ -1292,6 +1292,8 @@ void *linux_opendir(char *pathname, struct directory *dir)
 	return (void *) linuxdir;
 }
 
+int devtable_readdir(void *l, char *filename, char *dir_name, struct stat* devtable_inode_info);
+
 
 int linux_readdir(void *l, char *filename, char *dir_name, struct stat* devtable_inode_info)
 {

--- a/src/others/squashfs-3.0-e2100/mksquashfs.c
+++ b/src/others/squashfs-3.0-e2100/mksquashfs.c
@@ -1517,6 +1517,7 @@ void scan2_freedir(struct directory *dir)
 	free(dir->buff);
 }
 
+int dir_scan2(squashfs_inode *inode, struct dir_info *dir_info);
 
 void dir_scan(squashfs_inode *inode, char *pathname, int (_readdir)(char *, char *, struct dir_info *))
 {

--- a/src/others/squashfs-3.2-r2/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2/mksquashfs.c
@@ -2381,6 +2381,7 @@ void scan2_freedir(struct directory *dir)
 	free(dir->buff);
 }
 
+int dir_scan2(squashfs_inode *inode, struct dir_info *dir_info);
 
 void dir_scan(squashfs_inode *inode, char *pathname, int (_readdir)(char *, char *, struct dir_info *))
 {

--- a/src/others/squashfs-3.2-r2/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2/mksquashfs.c
@@ -1830,7 +1830,7 @@ int progress_bar(long long current, long long max, int columns)
 	int spaces = columns - used - hashes;
 
 	if(!progress || columns - used < 0)
-		return;
+		return 0;
 
 	printf("\r[");
 

--- a/src/others/squashfs-3.3/mksquashfs.c
+++ b/src/others/squashfs-3.3/mksquashfs.c
@@ -1927,7 +1927,7 @@ int progress_bar(long long current, long long max, int columns)
 	int spaces = columns - used - hashes;
 
 	if(!progress || columns - used < 0)
-		return;
+		return 0;
 
 	printf("\r[");
 

--- a/src/others/squashfs-3.3/sort.c
+++ b/src/others/squashfs-3.3/sort.c
@@ -74,7 +74,7 @@ struct sort_info *sort_info_list[65536];
 struct priority_entry *priority_list[65536];
 
 extern int silent;
-extern write_file(squashfs_inode *inode, struct dir_ent *dir_ent, int *c_size);
+extern int write_file(squashfs_inode *inode, struct dir_ent *dir_ent, int *c_size);
 
 
 int add_priority_list(struct dir_ent *dir, int priority)

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
@@ -2002,7 +2002,7 @@ void reader_scan(struct dir_info *dir) {
 				break;
 		}
 	}
-	return NULL;
+	return;
 }
 
 

--- a/src/others/squashfs-4.0-lzma/mksquashfs.c
+++ b/src/others/squashfs-4.0-lzma/mksquashfs.c
@@ -3473,7 +3473,7 @@ struct dir_info *dir_scan2(struct dir_info *dir, struct pseudo *pseudo)
 	struct dir_ent *dir_ent;
 	struct pseudo_entry *pseudo_ent;
 	struct stat buf;
-	static pseudo_ino = 1;
+	static int pseudo_ino = 1;
 	
 	if(dir == NULL && (dir = scan1_opendir("")) == NULL)
 		return NULL;

--- a/src/others/squashfs-4.0-lzma/unsquash-3.c
+++ b/src/others/squashfs-4.0-lzma/unsquash-3.c
@@ -36,7 +36,7 @@ int read_fragment_table_3()
 		sBlk.fragment_table_start);
 
 	if(sBlk.fragments == 0)
-		return;
+		return 1;
 
 	if((fragment_table = malloc(sBlk.fragments *
 			sizeof(squashfs_fragment_entry_3))) == NULL)

--- a/src/others/squashfs-4.0-lzma/unsquash-4.c
+++ b/src/others/squashfs-4.0-lzma/unsquash-4.c
@@ -38,7 +38,7 @@ int read_fragment_table_4()
 		sBlk.fragment_table_start);
 
 	if(sBlk.fragments == 0)
-		return;
+		return 1;
 
 	if((fragment_table = malloc(sBlk.fragments *
 			sizeof(squashfs_fragment_entry))) == NULL)

--- a/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
@@ -1541,6 +1541,7 @@ void scan2_freedir(struct directory *dir)
 	free(dir->buff);
 }
 
+int dir_scan2(squashfs_inode *inode, struct dir_info *dir_info);
 
 void dir_scan(squashfs_inode *inode, char *pathname, int (_readdir)(char *, char *, struct dir_info *))
 {

--- a/src/squashfs-3.0/mksquashfs.c
+++ b/src/squashfs-3.0/mksquashfs.c
@@ -1548,6 +1548,7 @@ void scan2_freedir(struct directory *dir)
 	free(dir->buff);
 }
 
+int dir_scan2(squashfs_inode *inode, struct dir_info *dir_info);
 
 void dir_scan(squashfs_inode *inode, char *pathname, int (_readdir)(char *, char *, struct dir_info *))
 {


### PR DESCRIPTION
First, there are some functions called before their declarations, causing implicit declaration errors.
```
mksquashfs.c: In function ‘dir_scan’:
mksquashfs.c:1590:9: error: implicit declaration of function ‘dir_scan2’; did you mean ‘dir_scan’? [-Wimplicit-function-declaration]
 1590 |         dir_scan2(inode, dir_info);
      |         ^~~~~~~~~
      |         dir_scan
make[1]: *** [<builtin>: mksquashfs.o] Error 1
```
This PR fixed it by declaring the prototype of before calling the function.

Second, according to the Linux manual page[1], the type of the third argument of `scandir` is `int (const struct dirent **, const struct dirent **)`. The wrong type of function will cause compile error if without explicit coercion.
```
mkcramfs.c: In function ‘parse_directory’:
mkcramfs.c:247:17: error: passing argument 4 of ‘scandir’ from incompatible pointer type [-Wincompatible-pointer-types]
  247 |                 cramsort);
      |                 ^~~~~~~~
      |                 |
      |                 int (*)(const void *, const void *)
```
This PR fixed it by correcting the function prototype.

Last, there are some non-void functions returning nothing and some void function returning non-void. This PR fixed them.

[1]:https://man7.org/linux/man-pages/man3/scandir.3.html