### PR TITLE
Additional GCC 15 and Python 3.14 Fixes

### DIFF
--- a/src/binwalk-2.1.1/src/binwalk/core/common.py
+++ b/src/binwalk-2.1.1/src/binwalk/core/common.py
@@ -209,8 +209,8 @@ class MathExpression(object):
         return self._eval(ast.parse(expr).body[0].value)
 
     def _eval(self, node):
-        if isinstance(node, ast.Num): # <number>
-            return node.n
+        if isinstance(node, ast.Constant): # <number>
+            return node.value
         elif isinstance(node, ast.operator): # <operator>
             return self.OPERATORS[type(node.op)]
         elif isinstance(node, ast.UnaryOp):

--- a/src/binwalk-2.1.1/src/binwalk/core/magic.py
+++ b/src/binwalk-2.1.1/src/binwalk/core/magic.py
@@ -404,7 +404,7 @@ class Magic(object):
         # Regex rule to find format strings
         self.fmtstr = re.compile("%[^%]")
         # Regex rule to find periods (see self._do_math)
-        self.period = re.compile("\.")
+        self.period = re.compile("\\.")
 
     def _filtered(self, text):
         '''
@@ -586,7 +586,7 @@ class Magic(object):
                 if line.operator:
                     try:
                         # If the operator value of this signature line is just an integer value, use it
-                        if isinstance(line.opvalue, int) or isinstance(line.opvalue, long):
+                        if isinstance(line.opvalue, int):
                             opval = line.opvalue
                         # Else, evaluate the complex expression
                         else:

--- a/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
+++ b/src/others/squashfs-2.0-nb4/nb4-mksquashfs/squashfs/mksquashfs.c
@@ -339,7 +339,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(interrupted == 1)
 		restorefs();

--- a/src/others/squashfs-2.2-r2-7z/mksquashfs.c
+++ b/src/others/squashfs-2.2-r2-7z/mksquashfs.c
@@ -320,7 +320,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(interrupted == 1)
 		restorefs();

--- a/src/others/squashfs-3.0-e2100/mksquashfs.c
+++ b/src/others/squashfs-3.0-e2100/mksquashfs.c
@@ -285,7 +285,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(interrupted == 1)
 		restorefs();
@@ -297,7 +297,7 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }

--- a/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-hg612-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
@@ -510,7 +510,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -523,13 +523,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -551,7 +551,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-lzma/squashfs3.2-r2/squashfs-tools/mksquashfs.c
@@ -510,7 +510,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -523,13 +523,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -551,7 +551,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.2-r2-rtn12/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-rtn12/mksquashfs.c
@@ -512,7 +512,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -525,13 +525,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -553,7 +553,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.2-r2-wnr1000/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2-wnr1000/mksquashfs.c
@@ -511,7 +511,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -524,13 +524,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -552,7 +552,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.2-r2/mksquashfs.c
+++ b/src/others/squashfs-3.2-r2/mksquashfs.c
@@ -506,7 +506,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -519,13 +519,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -547,7 +547,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.3-grml-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
@@ -546,7 +546,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -559,13 +559,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -587,7 +587,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.3-lzma/squashfs3.3/squashfs-tools/mksquashfs.c
@@ -547,7 +547,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -560,13 +560,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -588,7 +588,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.3/mksquashfs.c
+++ b/src/others/squashfs-3.3/mksquashfs.c
@@ -540,7 +540,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -553,13 +553,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -581,7 +581,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/mksquashfs.c
@@ -744,7 +744,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -757,13 +757,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -785,7 +785,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -797,7 +797,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-3.4-cisco/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.4-cisco/squashfs-tools/unsquashfs.c
@@ -256,7 +256,7 @@ struct test table[] = {
 void progress_bar(long long current, long long max, int columns);
 void update_progress_bar();
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -268,7 +268,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/mksquashfs.c
@@ -747,7 +747,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -760,13 +760,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -788,7 +788,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -800,7 +800,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-3.4-nb4/squashfs3.4/squashfs-tools/unsquashfs.c
@@ -259,7 +259,7 @@ struct test table[] = {
 void progress_bar(long long current, long long max, int columns);
 void update_progress_bar();
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -271,7 +271,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.0-lzma/mksquashfs.c
+++ b/src/others/squashfs-4.0-lzma/mksquashfs.c
@@ -782,7 +782,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -795,13 +795,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -823,7 +823,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -837,7 +837,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.0-lzma/unsquashfs.c
+++ b/src/others/squashfs-4.0-lzma/unsquashfs.c
@@ -109,7 +109,7 @@ struct test table[] = {
 void progress_bar(long long current, long long max, int columns);
 void update_progress_bar();
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -123,7 +123,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.0-realtek/mksquashfs.c
+++ b/src/others/squashfs-4.0-realtek/mksquashfs.c
@@ -774,7 +774,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -787,13 +787,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -815,7 +815,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -829,7 +829,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.0-realtek/unsquashfs.c
+++ b/src/others/squashfs-4.0-realtek/unsquashfs.c
@@ -112,7 +112,7 @@ struct test table[] = {
 void progress_bar(long long current, long long max, int columns);
 void update_progress_bar();
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -126,7 +126,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.2-official/mksquashfs.c
+++ b/src/others/squashfs-4.2-official/mksquashfs.c
@@ -797,7 +797,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -810,13 +810,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -838,7 +838,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -852,7 +852,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.2-official/unsquashfs.c
+++ b/src/others/squashfs-4.2-official/unsquashfs.c
@@ -116,7 +116,7 @@ struct test table[] = {
 void progress_bar(long long current, long long max, int columns);
 void update_progress_bar();
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 	struct winsize winsize;
 
@@ -130,7 +130,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.2/squashfs-tools/mksquashfs.c
+++ b/src/others/squashfs-4.2/squashfs-tools/mksquashfs.c
@@ -808,7 +808,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(++interrupted > 2)
 		return;
@@ -821,13 +821,13 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }
 
 
-void sigusr1_handler()
+void sigusr1_handler(int)
 {
 	int i;
 	sigset_t sigmask;
@@ -849,7 +849,7 @@ void sigusr1_handler()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 #ifndef __CYGWIN__
 	struct winsize winsize;
@@ -867,7 +867,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/others/squashfs-4.2/squashfs-tools/unsquashfs.c
+++ b/src/others/squashfs-4.2/squashfs-tools/unsquashfs.c
@@ -115,7 +115,7 @@ struct test table[] = {
 void progress_bar(long long current, long long max, int columns);
 void update_progress_bar();
 
-void sigwinch_handler()
+void sigwinch_handler(int)
 {
 #ifndef __CYGWIN__
 	struct winsize winsize;
@@ -133,7 +133,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int)
 {
 	rotate = (rotate + 1) % 4;
 }

--- a/src/squashfs-2.1-r2/mksquashfs.c
+++ b/src/squashfs-2.1-r2/mksquashfs.c
@@ -248,7 +248,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(interrupted == 1)
 		restorefs();

--- a/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
+++ b/src/squashfs-3.0-lzma-damn-small-variant/mksquashfs.c
@@ -302,7 +302,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(interrupted == 1)
 		restorefs();
@@ -314,7 +314,7 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }

--- a/src/squashfs-3.0/mksquashfs.c
+++ b/src/squashfs-3.0/mksquashfs.c
@@ -316,7 +316,7 @@ void restorefs()
 }
 
 
-void sighandler()
+void sighandler(int)
 {
 	if(interrupted == 1)
 		restorefs();
@@ -328,7 +328,7 @@ void sighandler()
 }
 
 
-void sighandler2()
+void sighandler2(int)
 {
 	EXIT_MKSQUASHFS();
 }


### PR DESCRIPTION
This is addition to PR #196. I also needed those changes for successful compilation of `src/`.

I ran into issues compiling the squashfs tools with gcc 15.2.1, mismatch function prototypes for signal handlers. The errors were many of:

```
mksquashfs.c: In function ‘main’:
mksquashfs.c:1924:33: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
 1924 |                 signal(SIGTERM, sighandler);
      |                                 ^~~~~~~~~~
      |                                 |
      |                                 void (*)(void)
In file included from mksquashfs.c:38:
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
mksquashfs.c:251:6: note: ‘sighandler’ declared here
  251 | void sighandler()
      |      ^~~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
```

I ran into issues running binwalk. `ast.Num` was deprecated in Python 3.8 and removed in Python 3.14. `long` and `int` are also the same type. The errors were:

```
/work/firmware-mod-kit/src/binwalk-2.1.1/src/binwalk/core/magic.py:407: SyntaxWarning: "\." is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
  self.period = re.compile("\.")

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------

Signature Exception: unsupported operand type(s) for +=: 'NoneType' and 'int'
----------------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/work/firmware-mod-kit/src/binwalk-2.1.1/src/binwalk/core/module.py", line 566, in main
    retval = self.run()
  File "/work/firmware-mod-kit/src/binwalk-2.1.1/src/binwalk/modules/signature.py", line 177, in run
    self.scan_file(fp)
    ~~~~~~~~~~~~~~^^^^
  File "/work/firmware-mod-kit/src/binwalk-2.1.1/src/binwalk/modules/signature.py", line 140, in scan_file
    for r in self.magic.scan(data, dlen):
             ~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/work/firmware-mod-kit/src/binwalk-2.1.1/src/binwalk/core/magic.py", line 760, in scan
    tags = self._analyze(signature, offset)
  File "/work/firmware-mod-kit/src/binwalk-2.1.1/src/binwalk/core/magic.py", line 549, in _analyze
    line_offset = self._do_math(offset, line_offset_text)
  File "/work/firmware-mod-kit/src/binwalk-2.1.1/src/binwalk/core/magic.py", line 475, in _do_math
    o += offset
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'
----------------------------------------------------------------------------------------------------
```